### PR TITLE
POC "Smart" Schema Validation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,7 @@ jobs:
             echo 'Waiting for db container...'
               sleep 1
             done
-            echo 'db container is up'    
+            echo 'db container is up'
 
       - run:
           name: db prep
@@ -114,7 +114,7 @@ jobs:
 
       - run:
           name: apollo service:check
-          command: sleep 5 && npx apollo service:check
+          command: sleep 5 && npx apollo service:check --validationPeriod=PT1H
 
       - run:
           name: apollo service:push if master

--- a/app/graphql/types/link_type.rb
+++ b/app/graphql/types/link_type.rb
@@ -4,6 +4,6 @@ module Types
     field :url, String, null: false
     field :description, String, null: false
     field :posted_by, UserType, null: false, method: :user
-    field :votes, [Types::VoteType], null: false
+    # field :votes, [Types::VoteType], null: false
   end
 end


### PR DESCRIPTION
https://www.apollographql.com/docs/platform/schema-validation.html#cli-advanced

TL;DR apollo schema validation via the CLI can actually be smart and factor in client usage, just have to actually use the `validationPeriod` flag.

Hence, removing a field here that has no recent usage. Expecting a `NOTICE` on the schema validation but not a warning or a failure.