### PR TITLE
Engine proxy now runs in a separate heroku app

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -2,29 +2,4 @@
 require "json"
 require_relative 'config/environment'
 
-unless ENV.key?("CI")
-  main_port = ENV.fetch("PORT") { 4000 }
-  proxy_port = ENV.fetch("APOLLO_ENGINE_PROXY_PORT").to_i
-
-  apollo_tracing_config = {
-    apiKey: ENV.fetch("ENGINE_API_KEY"),
-    logging: { level: "INFO" },
-    origins: [
-      {
-        http: {
-          url: "http://localhost:#{main_port}/graphql"
-        }
-      }
-    ],
-    frontends: [
-      {
-        host: "localhost",
-        port: proxy_port,
-        endpoints: ["/graphql"]
-      }
-    ]
-  }
-  ApolloTracing.start_proxy(apollo_tracing_config.to_json)
-end
-
 run Rails.application


### PR DESCRIPTION
https://github.com/TheMetalCode/engine-heroku-example

https://sample-graphql-ruby-proxy.herokuapp.com/graphql

This allows the apollo tracing to work in production and not locally.